### PR TITLE
Fix doc scope generation

### DIFF
--- a/templates/detail_record.dust
+++ b/templates/detail_record.dust
@@ -16,7 +16,7 @@
                 <td class="type">{>inline_type:type/}</td>
                 <td class="field">{name}{?order} <span class="label">{order}</span>{/order}</td>
                 <td class="field-doc">{default_str}</td>
-                <td class="field-doc">{doc|md|s}</td>
+                <td class="field-doc">{.doc|md|s}</td>
             </tr>
         {/fields}
         </tbody>


### PR DESCRIPTION
```
{
  "protocol" : "bug_docs",
  "namespace" : "space",
  "types" : [ {
    "type" : "record",
    "name" : "SomeRecord",
    "doc" : "Record description",
    "fields" : [ {
      "name" : "a",
      "type" : "string"
    }, {
      "name" : "b",
      "type" : "int"
    }, {
      "name" : "c",
      "type" : "int",
      "doc" : "C description"
    } ]
  } ],
  "messages" : { }
}
```
if we take this as an input, `Record description` populates both `a` and `b`.

<img width="1245" alt="Screen Shot 2020-06-09 at 19 43 02" src="https://user-images.githubusercontent.com/3982146/84176026-7c3f8300-aa89-11ea-81db-ca7148d51136.png">

After the fix:

<img width="1337" alt="Screen Shot 2020-06-09 at 19 44 08" src="https://user-images.githubusercontent.com/3982146/84176105-9bd6ab80-aa89-11ea-91f9-c7a625401f10.png">

More context how dust works: https://github.com/linkedin/dustjs/wiki/Dust-Tutorial#sections-and-context